### PR TITLE
Accept directory symlinks without trailing slash

### DIFF
--- a/bin/unburden-home-dir
+++ b/bin/unburden-home-dir
@@ -254,6 +254,13 @@ sub possibly_create_non_existing_stuff {
 sub fix_dangling_links {
     my ($type, $itemexpanded, $target) = @_;
     my $link = readlink($itemexpanded);
+    
+    
+    # Accept symlinks without trailing slash
+    if ( $type eq "d" or $type eq 'D' ) {
+      $link = $link."/" if ((!($link =~ /\/$/)) and -d $link);
+    }
+    
     # Check if link target is wanted target
     if ( $link ne $target ) {
 	report_problem($itemexpanded, "$link not equal $target");


### PR DESCRIPTION
It's possible to create symlinks for a directory without a trailing slash, i.e.

Desktop -> /user_data/.tmp/desktop.jvd

These weren't parsed correctly before:

WARNING: Can't handle /u/jvd/testdir: /user_data/.tmp/testdir.jvd not equal /user_data/.tmp/testdir.jvd/ at /usr/bin/unburden-home-dir line 184, 
<LIST> line 14.

This patch tests that the link is a directory and adds a trailing slash if required, to satisfy the following equivalence test.
