### PR TITLE
trailing slashes on reverts

### DIFF
--- a/bin/unburden-home-dir
+++ b/bin/unburden-home-dir
@@ -568,6 +568,10 @@ sub revert {
 
     if (-l $item_in_home) {
 	my $link_target = readlink($item_in_home);
+  $itemexpanded =~ s{/$}{};
+  $link_target  =~ s{/$}{};
+
+
 	if ($itemexpanded eq $link_target) {
 	    say "Removing symlink $item_in_home";
 	    unlink($item_in_home) unless $DRYRUN;


### PR DESCRIPTION
When trying to revert a symlink created by unburden-home-dirs:

Trying to revert /user_data/.tmp/app-icons.jvd to /u/jvd/app/config/Icons
Ignoring symlink /u/jvd/app/config/Icons as it points to /user_data/.tmp/app-icons.jvd/ and not to /user_data/.tmp/app-icons.jvd as expected.
 at /usr/bin/unburden-home-dir line 491
        main::revert('/user_data/.tmp/app-icons.jvd', 'app/config/Icons', 'app-icons') called at /usr/bin/unburden-home-dir line 551

Patch to remove the trailing slashes and move on with our lives.
