### PR TITLE
Use dh_mkdocs instead of symlinking static files manually

### DIFF
--- a/bin/unburden-home-dir
+++ b/bin/unburden-home-dir
@@ -26,7 +26,7 @@ use warnings;
 use 5.010;
 
 # Globally define version
-our $VERSION = '0.4.1.1';
+our $VERSION = '0.4.1.2';
 
 # Load Modules
 use Config::File;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+unburden-home-dir (0.4.1.2) UNRELEASED; urgency=medium
+
+  * Use dh_mkdocs instead of symlinking static files manually.
+
+ -- Dmitry Shachnev <mitya57@debian.org>  Sun, 16 Dec 2018 19:47:07 +0300
+
 unburden-home-dir (0.4.1.1) unstable; urgency=medium
 
   [ Jakub Wilk ]

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,7 @@ Build-Depends: debhelper (>= 11~),
                libtest-perl-critic-perl <!nocheck>,
                lsof <!nocheck>,
 # Required for building the documentation
-               mkdocs <!nodoc>,
+               mkdocs (>= 1.0.4) <!nodoc>,
                moreutils <!nodoc>,
 # Required for building the man pages
                ronn | ruby-ronn (<< 0.7.3-5.1~) <!nodoc>
@@ -103,7 +103,7 @@ Description: Remove or move cache files automatically from user's home
 
 Package: unburden-home-dir-doc
 Architecture: all
-Depends: ${misc:Depends}
+Depends: ${misc:Depends}, ${mkdocs:Depends}
 Recommends: fonts-font-awesome,
             libjs-mustache
 Enhances: unburden-home-dir

--- a/debian/rules
+++ b/debian/rules
@@ -16,10 +16,5 @@ override_dh_installman:
 else
 override_dh_install:
 	dh_install --fail-missing
-	rm -rf debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/fonts \
-	       debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/__pycache__ \
-	       debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/__init__.py \
-	       debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/search/mustache.min.js
-	ln -vis /usr/share/fonts-font-awesome/fonts debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/fonts
-	ln -vis /usr/share/javascript/mustache/mustache.min.js debian/unburden-home-dir-doc/usr/share/doc/unburden-home-dir/html/search/mustache.min.js
+	dh_mkdocs
 endif

--- a/debian/unburden-home-dir-doc.maintscript
+++ b/debian/unburden-home-dir-doc.maintscript
@@ -1,0 +1,1 @@
+symlink_to_dir /usr/share/doc/unburden-home-dir/html/fonts /usr/share/fonts-font-awesome/fonts 0.4.1.2~ unburden-home-dir-doc


### PR DESCRIPTION
I have created a new helper tool, [dh_mkdocs](https://manpages.debian.org/unstable/mkdocs/dh_mkdocs.1.en.html), which takes care of symlinking static files.

This pull request makes use of that tool instead of symlinking stuff manually. It is more future-proof: when mkdocs internal files change, only a rebuild will be needed to fix the links.