### PR TITLE
Add line format instruction directly to lists config file

### DIFF
--- a/etc/unburden-home-dir.list
+++ b/etc/unburden-home-dir.list
@@ -1,12 +1,12 @@
 ###############################################################################################
-# This is a configuration of folders, that unburden-home-dir will symlink to TARGETDIR
+# This is a configuration of folders, that unburden-home-dir will symlink to $TARGETDIR
 # All lines must be with columns using this order:
 # Action Type Path Identifier
 # Columns description
 # Action - d/r or m: delete/remove or move; the first two are equivalent
 # Type  - d, D, f or F: directory or file, capital letter means "create it if it doesn’t exist"
 # Path - path, relative to $HOME to move off to some other location
-# Identifier - optional identifier for file or directory in the other location
+# Identifier - name of file or directory in the $TARGETDIR
 ###############################################################################################
 
 # Generic cache locations


### PR DESCRIPTION
There are more detailed instruction exists, but when I start editing the `/etc/unburden-home-dir.list` I always forgot the abbreviations, so will be good to have them directly in file.